### PR TITLE
test: add unit tests for ImageFormat enum and ImageService.generateFilename

### DIFF
--- a/test/services/image_service_test.dart
+++ b/test/services/image_service_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:insta_grab/services/image_service.dart';
+
+void main() {
+  group('ImageService.generateFilename', () {
+    test('default prefix and extension produce expected format', () {
+      final filename = ImageService.generateFilename();
+      expect(filename, matches(RegExp(r'^insta_\d{8}_\d{6}\.png$')));
+    });
+
+    test('custom prefix and extension are respected', () {
+      final filename =
+          ImageService.generateFilename(prefix: 'test', ext: 'jpg');
+      expect(filename, matches(RegExp(r'^test_\d{8}_\d{6}\.jpg$')));
+    });
+  });
+}

--- a/test/services/settings_service_test.dart
+++ b/test/services/settings_service_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:insta_grab/services/settings_service.dart';
+
+void main() {
+  group('ImageFormat enum', () {
+    test('PNG has correct label and extension', () {
+      expect(ImageFormat.png.label, 'PNG');
+      expect(ImageFormat.png.extension, 'png');
+    });
+
+    test('JPEG has correct label and extension', () {
+      expect(ImageFormat.jpeg.label, 'JPEG');
+      expect(ImageFormat.jpeg.extension, 'jpg');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

First batch of unit tests from the test coverage initiative (#13). Implements two low-effort test groups — pure-logic functions with zero dependencies or mocking.

## Changes

### New files
- `test/services/settings_service_test.dart` — ImageFormat enum value assertions (2 tests)
- `test/services/image_service_test.dart` — ImageService.generateFilename format checks (2 tests)

### 4 tests, all passing
```
00:00 +4: All tests passed!
```

## Issues addressed

- Closes #11 — ImageFormat enum values
- Closes #9 — ImageService.generateFilename

## Meta

Part of the [#13](https://github.com/DavidJBarnes/instagrab/issues/13) meta initiative for initial unit test coverage.