### PR TITLE
test: add 8 unit tests for InstagramService.normalizeUrl (#3)

### DIFF
--- a/test/services/instagram_service_test.dart
+++ b/test/services/instagram_service_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:insta_grab/services/instagram_service.dart';
+
+void main() {
+  group('InstagramService.normalizeUrl', () {
+    test('1. Debería retornar la URL canónica estándar', () {
+      expect(InstagramService.normalizeUrl('https://www.instagram.com/p/ABC123/'), 
+             'https://www.instagram.com/p/ABC123/');
+    });
+
+    test('2. Debería añadir "www" si falta', () {
+      expect(InstagramService.normalizeUrl('https://instagram.com/p/ABC123/'), 
+             'https://www.instagram.com/p/ABC123/');
+    });
+
+    test('3. Debería convertir /reel/ a /p/', () {
+      expect(InstagramService.normalizeUrl('https://www.instagram.com/reel/ABC123/'), 
+             'https://www.instagram.com/p/ABC123/');
+    });
+
+    test('4. Debería convertir /tv/ a /p/', () {
+      expect(InstagramService.normalizeUrl('https://www.instagram.com/tv/ABC123/'), 
+             'https://www.instagram.com/p/ABC123/');
+    });
+
+    test('5. Debería limpiar parámetros de consulta (query params)', () {
+      expect(InstagramService.normalizeUrl('https://www.instagram.com/p/ABC123/?utm_source=share'), 
+             'https://www.instagram.com/p/ABC123/');
+    });
+
+    test('6. Debería limpiar fragmentos (#)', () {
+      expect(InstagramService.normalizeUrl('https://www.instagram.com/p/ABC123/#fragment'), 
+             'https://www.instagram.com/p/ABC123/');
+    });
+
+    test('7. Debería retornar null para URLs que no son de Instagram', () {
+      expect(InstagramService.normalizeUrl('https://twitter.com/user/status/123'), isNull);
+    });
+
+    test('8. Debería retornar null para strings vacíos', () {
+      expect(InstagramService.normalizeUrl(''), isNull);
+    });
+  });
+}


### PR DESCRIPTION
I have implemented a suite of 8 unit tests for the `normalizeUrl` method in `InstagramService`. These tests ensure that Instagram URL processing is robust and correctly handles various formats.

 Included Test Cases:
1. Return standard canonical URL.
2. Automatically add "www" if missing.
3. Convert `/reel/` paths to `/p/`.
4. Convert `/tv/` paths to `/p/`.
5. Clean query parameters (query params).
6. Clean URL fragments (#).
7. Validate non-Instagram URLs (returns null).
8. Handle empty strings (returns null).

 Verification
 Tests were executed locally using the Flutter SDK.
 Result: 8/8 tests passed.

Closes #3.