### PR TITLE
fix & test: implement shortcode decoding and fix validation (#4)

### DIFF
--- a/lib/services/instagram_service.dart
+++ b/lib/services/instagram_service.dart
@@ -40,6 +40,9 @@ class InstagramService {
   /// The result exceeds 2^53 so a `BigInt` is used throughout; the
   /// stringified form is what the `/api/v1/` endpoint expects.
   static String shortcodeToMediaId(String shortcode) {
+    if (shortcode.isEmpty) {
+      throw const InstagramExtractionException('Shortcode cannot be empty.');
+    }
     var n = BigInt.zero;
     final base = BigInt.from(64);
     for (final rune in shortcode.runes) {

--- a/test/services/instagram_service_test.dart
+++ b/test/services/instagram_service_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:insta_grab/services/instagram_service.dart';
+
+void main() {
+  group('InstagramService.normalizeUrl', () {
+    test('1. Debería retornar la URL canónica estándar', () {
+      expect(InstagramService.normalizeUrl('https://www.instagram.com/p/ABC123/'), 
+             'https://www.instagram.com/p/ABC123/');
+    });
+
+    test('2. Debería añadir "www" si falta', () {
+      expect(InstagramService.normalizeUrl('https://instagram.com/p/ABC123/'), 
+             'https://www.instagram.com/p/ABC123/');
+    });
+
+    test('3. Debería convertir /reel/ a /p/', () {
+      expect(InstagramService.normalizeUrl('https://www.instagram.com/reel/ABC123/'), 
+             'https://www.instagram.com/p/ABC123/');
+    });
+
+    test('4. Debería convertir /tv/ a /p/', () {
+      expect(InstagramService.normalizeUrl('https://www.instagram.com/tv/ABC123/'), 
+             'https://www.instagram.com/p/ABC123/');
+    });
+
+    test('5. Debería limpiar parámetros de consulta (query params)', () {
+      expect(InstagramService.normalizeUrl('https://www.instagram.com/p/ABC123/?utm_source=share'), 
+             'https://www.instagram.com/p/ABC123/');
+    });
+
+    test('6. Debería limpiar fragmentos (#)', () {
+      expect(InstagramService.normalizeUrl('https://www.instagram.com/p/ABC123/#fragment'), 
+             'https://www.instagram.com/p/ABC123/');
+    });
+
+    test('7. Debería retornar null para URLs que no son de Instagram', () {
+      expect(InstagramService.normalizeUrl('https://twitter.com/user/status/123'), isNull);
+    });
+
+    test('8. Debería retornar null para strings vacíos', () {
+      expect(InstagramService.normalizeUrl(''), isNull);
+    });
+  });
+}

--- a/test/services/instagram_service_test.dart
+++ b/test/services/instagram_service_test.dart
@@ -40,5 +40,32 @@ void main() {
     test('8. Debería retornar null para strings vacíos', () {
       expect(InstagramService.normalizeUrl(''), isNull);
     });
+
+    group('shortcodeToMediaId', () {
+      test('should return "1" when shortcode is "B"', () {
+        final result = InstagramService.shortcodeToMediaId('B');
+        expect(result, equals('1'));
+      });
+
+      test('should correctly decode a known real shortcode', () {
+        // Real example: /p/Ct_7366MA_u/ -> media_id: 3134487193241784302
+        final result = InstagramService.shortcodeToMediaId('Ct_7366MA_u');
+        expect(result, equals('3134487193241784302'));
+      });
+
+      test('should throw InstagramExtractionException when shortcode is empty', () {
+        expect(
+          () => InstagramService.shortcodeToMediaId(''),
+          throwsA(isA<InstagramExtractionException>()),
+        );
+      });
+
+      test('should throw InstagramExtractionException when shortcode is invalid', () {
+        expect(
+          () => InstagramService.shortcodeToMediaId('!!!invalid'),
+          throwsA(isA<InstagramExtractionException>()),
+        );
+      });
+    });
   });
 }


### PR DESCRIPTION
I have implemented 4 unit tests for the shortcodeToMediaId method as requested in Issue #4. During implementation, I identified and fixed a validation bug and a mathematical discrepancy in the expected output.

Changes Made:

Bug Fix: Added validation for empty strings. Previously, the method returned 0, but it now correctly throws an InstagramExtractionException.

Logic Correction: Updated the expected media ID for the shortcode Ct_7366MA_u. Based on Instagrams base-64 alphabet, the correct numeric ID is 3134487193241784302.

New Tests: Added 4 test cases covering basic decoding, real-world shortcodes, empty strings, and invalid characters.

Verification:

All 12 tests (8 from PR 15 + 4 new) passed successfully using the Flutter SDK.

Closes #4.